### PR TITLE
Fix the exception caused by not configuring telegram-bot.template.

### DIFF
--- a/telegram-bot-ktor/src/main/kotlin/io/github/dehuckakpyt/telegrambot/factory/template/TemplateFactory.kt
+++ b/telegram-bot-ktor/src/main/kotlin/io/github/dehuckakpyt/telegrambot/factory/template/TemplateFactory.kt
@@ -14,7 +14,7 @@ import kotlin.properties.PropertyDelegateProvider
  * @author Denis Matytsin
  */
 object TemplateFactory {
-    private val telegramBotTemplate = InternalKoinContext.koin.get<ApplicationConfig>(named("telegramBotTemplate"))
+    private val telegramBotTemplate = InternalKoinContext.koin.getOrNull<ApplicationConfig>(named("telegramBotTemplate")) ?: MapApplicationConfig()
 
     fun property(): PropertyDelegateProvider<Any?, Lazy<String>> = PropertyDelegateProvider { _, property ->
         lazy { getProperty(property.name.toKebabCase()) }

--- a/telegram-bot-ktor/src/main/kotlin/io/github/dehuckakpyt/telegrambot/plugin/TelegramBot.kt
+++ b/telegram-bot-ktor/src/main/kotlin/io/github/dehuckakpyt/telegrambot/plugin/TelegramBot.kt
@@ -30,16 +30,13 @@ import org.koin.mp.KoinPlatform.getKoin
  * @author Denis Matytsin
  */
 val TelegramBot = createApplicationPlugin(name = "telegram-bot", "telegram-bot", { TelegramBotConfig() }) {
-    val appConfig = application.environment.config
-    if (pluginConfig.token == null) pluginConfig.token = appConfig.tryGetString("telegram-bot.token")
-    if (pluginConfig.username == null) pluginConfig.username = appConfig.tryGetString("telegram-bot.username")
+    val telegramBotConfig = application.environment.config.config("telegram-bot")
+    if (pluginConfig.token == null) pluginConfig.token = telegramBotConfig.tryGetString("token")
+    if (pluginConfig.username == null) pluginConfig.username = telegramBotConfig.tryGetString("username")
     if (pluginConfig.receiving.messageTemplate == null) pluginConfig.receiving.messageTemplate = { KtorMessageTemplate() }
 
-    try {
-        InternalKoinContext.koin.declare<ApplicationConfig>(appConfig.config("telegram-bot.template"), named("telegramBotTemplate"))
-    } catch (e: ApplicationConfigurationException) {
-        application.log.warn("No telegram-bot.template configuration found. Using empty configuration.")
-        InternalKoinContext.koin.declare<ApplicationConfig>(MapApplicationConfig(), named("telegramBotTemplate"))
+    if ("template" in telegramBotConfig.keys()) {
+        InternalKoinContext.koin.declare<ApplicationConfig>(telegramBotConfig.config("template"), named("telegramBotTemplate"))
     }
 
     val context = TelegramBotFactory.createTelegramBotContext(pluginConfig)

--- a/telegram-bot-ktor/src/main/kotlin/io/github/dehuckakpyt/telegrambot/plugin/TelegramBot.kt
+++ b/telegram-bot-ktor/src/main/kotlin/io/github/dehuckakpyt/telegrambot/plugin/TelegramBot.kt
@@ -35,7 +35,12 @@ val TelegramBot = createApplicationPlugin(name = "telegram-bot", "telegram-bot",
     if (pluginConfig.username == null) pluginConfig.username = appConfig.tryGetString("telegram-bot.username")
     if (pluginConfig.receiving.messageTemplate == null) pluginConfig.receiving.messageTemplate = { KtorMessageTemplate() }
 
-    InternalKoinContext.koin.declare<ApplicationConfig>(appConfig.config("telegram-bot.template"), named("telegramBotTemplate"))
+    try {
+        InternalKoinContext.koin.declare<ApplicationConfig>(appConfig.config("telegram-bot.template"), named("telegramBotTemplate"))
+    } catch (e: ApplicationConfigurationException) {
+        application.log.warn("No telegram-bot.template configuration found. Using empty configuration.")
+        InternalKoinContext.koin.declare<ApplicationConfig>(MapApplicationConfig(), named("telegramBotTemplate"))
+    }
 
     val context = TelegramBotFactory.createTelegramBotContext(pluginConfig)
     val telegramBot = context.telegramBot

--- a/telegram-bot-ktor/src/main/kotlin/io/github/dehuckakpyt/telegrambot/plugin/TelegramBot.kt
+++ b/telegram-bot-ktor/src/main/kotlin/io/github/dehuckakpyt/telegrambot/plugin/TelegramBot.kt
@@ -35,7 +35,7 @@ val TelegramBot = createApplicationPlugin(name = "telegram-bot", "telegram-bot",
     if (pluginConfig.username == null) pluginConfig.username = telegramBotConfig.tryGetString("username")
     if (pluginConfig.receiving.messageTemplate == null) pluginConfig.receiving.messageTemplate = { KtorMessageTemplate() }
 
-    if ("template" in telegramBotConfig.keys()) {
+    if (telegramBotConfig.propertyOrNull("template") != null) {
         InternalKoinContext.koin.declare<ApplicationConfig>(telegramBotConfig.config("template"), named("telegramBotTemplate"))
     }
 


### PR DESCRIPTION
I'm using Ktor's YAML configuration, and if I don't include a configuration block like this:

```yaml
telegram-bot:
  template:
    xx: xx
```
an exception will occur. When such a configuration is missing, Koin will inject an empty `ApplicationConfig` object.