### PR TITLE
When callback_data is less than 64 bytes instead of length, use callback_id

### DIFF
--- a/telegram-bot-core/src/main/kotlin/io/github/dehuckakpyt/telegrambot/converter/SimpleCallbackSerializer.kt
+++ b/telegram-bot-core/src/main/kotlin/io/github/dehuckakpyt/telegrambot/converter/SimpleCallbackSerializer.kt
@@ -38,7 +38,7 @@ class SimpleCallbackSerializer(
 
         val data = dataConverter.toContent(instance)
 
-        if (data.length + next.length <= 62) {
+        if ((data + next).toByteArray().size <= 62) {
             //will be string stepName|scallbackData (string)
             return "$next$delimiter${CallbackDataType.STRING}$data"
         }


### PR DESCRIPTION
When callback_data is less than 64 bytes instead of length, use callback_id

https://core.telegram.org/bots/api#callbackquery

```
Optional. Data to be sent in a [callback query](https://core.telegram.org/bots/api#callbackquery) to the bot when the button is pressed, 1-64 bytes
```

It's bytes, not length


